### PR TITLE
Movement Overhaul

### DIFF
--- a/NPC_crate.py
+++ b/NPC_crate.py
@@ -51,66 +51,20 @@ class Crate(Character, Collidable):
         self.collider.image = pygame.Surface([Settings.tile_size, Settings.tile_size])
         self.collider.rect = self.collider.image.get_rect()
 
-    def move_left(self):
-        self.collisions = []
-        amount = self.delta * Updateable.gameDeltaTime
+    def move(self, direction):
+        amount = self.delta * Updateable.gameDeltaTime * direction
         try:
-            if self.x - amount < 0:
-                raise OffScreenLeftException
-            else:
-                self.x = self.x - amount
-                self.update(0)
-                if len(self.collisions) != 0:
-                    self.x = self.x + amount
-                    self.update(0)
-                    self.collisions = []
-        except:
-            pass
-
-    def move_right(self):
-        self.collisions = []
-        amount = self.delta * Updateable.gameDeltaTime
-        try:
-            if self.x + amount > self.world_size[0] - Settings.tile_size:
+            if self.x + amount.x < 0:
+                raise OffScreenLeftException            
+            elif self.x + amount.x > self.world_size[0] - Settings.tile_size:
                 raise OffScreenRightException
-            else:
-                self.x = self.x + amount
-                self.update(0)
-                if len(self.collisions) != 0:
-                    self.x = self.x - amount
-                    self.update(0)
-                    self.collisions = []
-        except:
-            pass
-
-    def move_up(self):
-        self.collisions = []
-        amount = self.delta * Updateable.gameDeltaTime
-        try:
-            if self.y - amount < 0:
+            elif self.y + amount.y < 0:
                 raise OffScreenTopException
-            else:
-                self.y = self.y - amount
-                self.update(0)
-                if len(self.collisions) != 0:
-                    self.y = self.y + amount
-                    self.update(0)
-                    self.collisions = []
-        except:
-            pass
-
-    def move_down(self):
-        amount = self.delta * Updateable.gameDeltaTime
-        try:
-            if self.y + amount > self.world_size[1] - Settings.tile_size:
+            elif self.y + amount.y > self.world_size[1] - Settings.tile_size:
                 raise OffScreenBottomException
             else:
-                self.y = self.y + amount
-                self.update(0)
-                if len(self.collisions) != 0:
-                    self.y = self.y - amount
-                    self.update(0)
-                    self.collisions = []
+                self.x += amount.x
+                self.y += amount.y
         except:
             pass
 
@@ -127,16 +81,8 @@ class Crate(Character, Collidable):
         
 
     def onCollision(self, collision, direction):
-        #Quick and dirty movement code to test collision.
-        if abs(direction.x) > abs(direction.y):
-            if direction.x > 0:
-                self.move_right()
-            elif direction.x < 0:
-                self.move_left()
+        if(abs(direction.x) > abs(direction.y)):
+            direction.y = 0
         else:
-            if direction.y > 0:
-                self.move_down()
-            elif direction.y < 0:
-                self.move_up() 
-            else:
-                print("Unknown Direction.")
+            direction.x = 0
+        self.move(direction.normalize())

--- a/league/engine.py
+++ b/league/engine.py
@@ -43,6 +43,7 @@ class Engine:
         self.visible_statistics = False
         self.statistics_font = None
         self.collisions = {}
+        self.gameEvents = []
 
     def init_pygame(self):
         """This function sets up the state of the pygame system,
@@ -139,12 +140,14 @@ class Engine:
     # it works as long as you don't want multiple functions
     # to be called per event.
     def handle_inputs(self):
-        for event in pygame.event.get():
+        self.gameEvents = pygame.event.get()
+        for event in self.gameEvents:
             # Check "normal" events
             if event.type in self.events.keys():
                 self.events[event.type](self.game_delta_time)
             # Check if these key_event keys were pressed
             if event.type == pygame.KEYDOWN:
                 if event.key in self.key_events.keys():
-                    self.key_events[event.key]() 
+                    self.key_events[event.key]()
+            
 

--- a/player.py
+++ b/player.py
@@ -1,6 +1,7 @@
 from league import *
 from league.game_objects import Updateable
 from collision import Collision, Collidable
+from pygame import Vector3
 import pygame
 from range_shot import Ranged_Shot
 
@@ -22,6 +23,9 @@ class Player(Character, Collidable):
         self.last_hit = pygame.time.get_ticks()
         # A unit-less value.  Bigger is faster.
         self.delta = 100
+
+        # The direction the player is facing. Should be a unit vector.
+        self.direction = Vector3(0, 0, 0)
 
         #flag to tell us if we need to flip image or not
         self.setFlip = False
@@ -186,3 +190,33 @@ class Player(Character, Collidable):
         if now - self.last_hit > 1000:
             self.health = self.health - 10
             self.last_hit = now
+
+    #This might be able to be broken up into methods.
+    def handleInput(self):
+        for event in pygame.event.get():
+            if event.type == pygame.KEYDOWN:
+                # Ideally these would be stored in a constants file but it works for now.
+                if event.key == pygame.K_RIGHT:
+                    self.direction.x = 1
+                if event.key == pygame.K_LEFT:
+                    self.direction.x = -1
+                if event.key == pygame.K_UP:
+                    self.direction.y = -1
+                if event.key == pygame.K_DOWN:
+                    self.direction.y = 1
+                self.direction = self.direction.normalize()
+
+            if event.type == pygame.KEYUP:
+                # Ideally these would be stored in a constants file but it works for now.
+                if event.key == pygame.K_RIGHT:
+                    self.direction.x = 0
+                if event.key == pygame.K_LEFT:
+                    self.direction.x = 0
+                if event.key == pygame.K_UP:
+                    self.direction.y = 0
+                if event.key == pygame.K_DOWN:
+                    self.direction.y = 0
+                self.direction = self.direction.normalize()
+
+
+

--- a/player.py
+++ b/player.py
@@ -137,19 +137,7 @@ class Player(Character, Collidable):
                     Collision(self, sprite)
 
     def onCollision(self, collision, direction):
-        if abs(direction.x) > abs(direction.y):
-            if direction.x > 0:
-                self.move(Vector3())
-            elif direction.x < 0:
-                self.move_left()
-                #TODO Change the things to vectors.
-        else:
-            if direction.y > 0:
-                self.move_down()
-            elif direction.y < 0:
-                self.move_up() 
-            else:
-                print("Unknown Direction.")
+        self.move(direction.normalize())
 
 
     def ouch(self):

--- a/player.py
+++ b/player.py
@@ -139,6 +139,10 @@ class Player(Character, Collidable):
                     Collision(self, sprite)
 
     def onCollision(self, collision, direction):
+        if(abs(direction.x) > abs(direction.y)):
+            direction.y = 0
+        else:
+            direction.x = 0
         self.move(direction.normalize())
 
 

--- a/player.py
+++ b/player.py
@@ -77,62 +77,20 @@ class Player(Character, Collidable):
 
         self.scene = scene
 
-    def move_left(self):
-        self.setFlip = True
-        self.isMoving = True
-        amount = self.delta * Updateable.gameDeltaTime
+    def move(self, direction):
+        amount = self.delta * Updateable.gameDeltaTime * direction
         try:
-            if self.x - amount < 0:
-                raise OffScreenLeftException
-            else:
-                self.x = self.x - amount
-                self.update(0)
-                self.isMoving = False
-
-        except:
-            pass
-
-    def move_right(self):
-        self.setFlip = False
-        self.isMoving = True
-
-        amount = self.delta * Updateable.gameDeltaTime
-        try:
-            if self.x + amount > self.world_size[0] - Settings.tile_size:
+            if self.x + amount.x < 0:
+                raise OffScreenLeftException            
+            elif self.x + amount.x > self.world_size[0] - Settings.tile_size:
                 raise OffScreenRightException
-            else:
-                self.x = self.x + amount
-                self.update(0)
-                self.isMoving = False
-
-        except:
-            pass
-
-    def move_up(self):
-        self.isMoving = True
-
-        amount = self.delta * Updateable.gameDeltaTime
-        try:
-            if self.y - amount < 0:
+            elif self.y + amount.y < 0:
                 raise OffScreenTopException
-            else:
-                self.y = self.y - amount
-                self.update(0)
-                self.isMoving = False
-
-        except:
-            pass
-
-    def move_down(self):
-        self.isMoving = True
-        amount = self.delta * Updateable.gameDeltaTime
-        try:
-            if self.y + amount > self.world_size[1] - Settings.tile_size:
+            elif self.y + amount.y > self.world_size[1] - Settings.tile_size:
                 raise OffScreenBottomException
             else:
-                self.y = self.y + amount
-                self.update(0)
-                self.isMoving = False
+                self.x += amount.x
+                self.y += amount.y
         except:
             pass
 
@@ -153,6 +111,14 @@ class Player(Character, Collidable):
         self.rect.x = self.x
         self.rect.y = self.y
         self.index = (self.index + 1) % len(self.idleImages)
+
+        #If player's direction is not 0, 0, 0, player is moving.
+        if self.direction != Vector3(0,0,0):
+            self.isMoving = False
+        else:
+            self.isMoving = True
+
+        #Load animations based on movement state.
         if self.isMoving == False:
             self.image = pygame.image.load(self.idleImages[self.index]).convert_alpha()
         elif self.isMoving == True:
@@ -173,9 +139,10 @@ class Player(Character, Collidable):
     def onCollision(self, collision, direction):
         if abs(direction.x) > abs(direction.y):
             if direction.x > 0:
-                self.move_right()
+                self.move(Vector3())
             elif direction.x < 0:
                 self.move_left()
+                #TODO Change the things to vectors.
         else:
             if direction.y > 0:
                 self.move_down()
@@ -198,8 +165,10 @@ class Player(Character, Collidable):
                 # Ideally these would be stored in a constants file but it works for now.
                 if event.key == pygame.K_RIGHT:
                     self.direction.x = 1
+                    self.setFlip = False
                 if event.key == pygame.K_LEFT:
                     self.direction.x = -1
+                    self.setFlip = True
                 if event.key == pygame.K_UP:
                     self.direction.y = -1
                 if event.key == pygame.K_DOWN:

--- a/player.py
+++ b/player.py
@@ -111,12 +111,14 @@ class Player(Character, Collidable):
         self.rect.x = self.x
         self.rect.y = self.y
         self.index = (self.index + 1) % len(self.idleImages)
+        self.handleInput()
 
         #If player's direction is not 0, 0, 0, player is moving.
         if self.direction != Vector3(0,0,0):
-            self.isMoving = False
-        else:
             self.isMoving = True
+            self.move(self.direction)
+        else:
+            self.isMoving = False
 
         #Load animations based on movement state.
         if self.isMoving == False:
@@ -148,7 +150,7 @@ class Player(Character, Collidable):
 
     #This might be able to be broken up into methods.
     def handleInput(self):
-        for event in pygame.event.get():
+        for event in self.scene.engine.gameEvents:
             if event.type == pygame.KEYDOWN:
                 # Ideally these would be stored in a constants file but it works for now.
                 if event.key == pygame.K_RIGHT:
@@ -161,7 +163,9 @@ class Player(Character, Collidable):
                     self.direction.y = -1
                 if event.key == pygame.K_DOWN:
                     self.direction.y = 1
-                self.direction = self.direction.normalize()
+                #TODO see why even when check passes, normalize thinks the vector has length 0.
+                #if self.direction.length != 0:
+                #    self.direction = self.direction.normalize()
 
             if event.type == pygame.KEYUP:
                 # Ideally these would be stored in a constants file but it works for now.
@@ -173,7 +177,9 @@ class Player(Character, Collidable):
                     self.direction.y = 0
                 if event.key == pygame.K_DOWN:
                     self.direction.y = 0
-                self.direction = self.direction.normalize()
+               #TODO see why even when check passes, normalize thinks the vector has length 0.
+               # if self.direction.length != 0:
+                #    self.direction = self.direction.normalize()
 
 
 

--- a/scene.py
+++ b/scene.py
@@ -125,11 +125,6 @@ class Scene(league.game_objects.Drawable):
         engine.key_events[pygame.K_w] = player.shoot_up
         engine.key_events[pygame.K_s] = player.shoot_down
 
-        engine.key_events[pygame.K_LEFT] = player.move_left
-        engine.key_events[pygame.K_RIGHT] = player.move_right
-        engine.key_events[pygame.K_UP] = player.move_up
-        engine.key_events[pygame.K_DOWN] = player.move_down
-
     def render_background(self):
         background = pygame.Surface((self.__width * TILE_WIDTH, self.__height * TILE_HEIGHT))
         for x in range(0, self.__width):

--- a/scene.py
+++ b/scene.py
@@ -34,7 +34,7 @@ class Scene(league.game_objects.Drawable):
 
 
 
-        self.__engine = engine
+        self.engine = engine
         self.__width = data['width']
         self.__height = data['height']
         self.__background = [[TileType.empty for y in range(0, data['height'])] for x in range(0, data['width'])]


### PR DESCRIPTION
Changes movement to work based on vectors instead of individual move direction commands. Currently, player can move diagonally but collisions still respond in cardinal directions to prevent the player/crates sliding around each other.

**Known issue:** Player can clip through certain walls with diagonal movement when collisions are set to cardinal directions. I believe this is due to the sprite size mismatch with the player. 
Example: Player collides with bottom wall on a diagonal. The collision gives the vector direction of this, then in onCollide, whichever axis is a smaller magnitude is set to zero to force cardinal directions.
On certain approaches, this makes the player bounce horizontally instead of up and away from the wall, allowing them to clip down through the wall.